### PR TITLE
Added Theycallitcrypto to Useful Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ watch.
 * [EtherChain](https://etherchain.org) - Ethereum Blockchain Explorer.
 * [Trivial.co](https://trivial.co) - Network explorer and analytics platform for Ethereum and ERC-20 tokens.
 * [HappyDApps](https://happydapps.net) - Web 3.0 browser compatibility check.
+* [Theycallitcrypto](https://theycallitcrypto.com/) - Find cryptocurrency exchanges based on the coin you want, payment method and country.
 # Video
 ## YouTube Channels
 * [The Cryptoverse](https://www.youtube.com/channel/UCLnQ34ZBSjy2JQjeRudFEDw) - Your cryptocurrency news dose.


### PR DESCRIPTION
I added [Theycallitcrypto](https://theycallitcrypto.com) to Useful Tools.

It's an easy tool for crypto newbies to use and an awesome site to refer people to whenever you get the question "How do I buy cryptocurrency?"

Price trackers like coinmarketcap are great, but not for rookies. And most price tracking sites don't document the payment methods offered or countries supported by each exchange. 

The site also has a growing number of exchange reviews, tutorials and Q&A posts related to all things crypto.  